### PR TITLE
fix "ValueError: max()" in LPA.get_max_neighbor_label()

### DIFF
--- a/algorithm/LPA.py
+++ b/algorithm/LPA.py
@@ -28,6 +28,11 @@ class LPA():
         for neighbor_index in self._G.neighbors(node_index):
             neighbor_label = self._G.node[neighbor_index]["label"]
             m[neighbor_label] += 1
+
+        if(not bool(m)):
+            #return label of the vertex itself if it's an isolated vertex
+            return [self._G.node[node_index]["label"]]
+
         max_v = max(m.itervalues())
         return [item[0] for item in m.items() if item[1] == max_v]
 


### PR DESCRIPTION
max(m.itervalues()) will raise ValueError when calling `LPA.get_max_neighbor_label()`
with a parameter isolated vertex, which has no neighbors.
It is reasonable to return label of the vertex itself if it's an isolated vertex.

pass empty sequence parameter to max():
```
>>> m=dict()
>>> max(m.itervalues())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: max() arg is an empty sequence
```

fix #9